### PR TITLE
add option to save outputs to file, Close #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you wish to modify the paths or input files, adjust the `forcings_path` and
 
 Example:
 ```
-ra = run_model('path_to_forcing_data/', 'path_to_parameters/parameters.mat')
+ra = run_model('path_to_forcing_data/', 'path_to_parameters/parameters.mat', 'path_to_outputs')
 ```
 
 5. Output

--- a/run_main.py
+++ b/run_main.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     print('Starting pySnowClim model...')
     
-    model_output = run_model('data/', 'data/parameters.mat')
+    model_output = run_model('data/', 'data/parameters.mat', 'outputs/')
     print('pySnowClim model finished!')
 
 

--- a/src/runsnowclim_model.py
+++ b/src/runsnowclim_model.py
@@ -11,6 +11,7 @@ The script can be adapted for different parameters, time periods, or datasets.
 import os
 import pickle
 import scipy.io
+import numpy as np
 
 from createParameterFile import create_dict_parameters
 from snowclim_model import run_snowclim_model
@@ -83,8 +84,28 @@ def _load_parameter_file(parameterfilename):
     return parameters
 
 
+def _save_outputs(model_output, outputs_path=None):
+    """
+    Save model outputs to file.
 
-def run_model(forcings_path, parameters_path):
+    Args:
+        model_output (class): class containing snow model outputs
+        outputs_path (str): name of directory to save outputs to.
+
+    Returns:
+        nothing
+    """
+    if outputs_path is not None:
+    # TODO: here or perhaps before the model runs, add a check that the output directory exists
+    # TODO: for now, saving these as .npy because it is easy and avoids added complications. 
+    #       May want to save in a more accessible format eventually.
+        variables_to_save = list(vars(model_output).keys())
+        variables_to_save.remove('outdim')
+        for v in variables_to_save:
+            np.save(outputs_path + v + '.npy', getattr(model_output,v))
+
+
+def run_model(forcings_path, parameters_path, outputs_path):
     
     print('Loading necessary files...')
     parameters = _load_parameter_file(parameters_path)
@@ -93,5 +114,7 @@ def run_model(forcings_path, parameters_path):
     print('Files loaded, running the model...')
     model_output = run_snowclim_model(forcings_data, parameters)
     
+    _save_outputs(model_output, outputs_path)
+
     return model_output
     


### PR DESCRIPTION
Here's one approach to saving options from the model. Aranildo, don't hesitate to let me know if you see a better way to do this. I just saved to .npy for now since it is straightforward. Eventually we may want to save to a file type that is more easily accessible from other software programs. I also think we should check that the output directory exists, but couldn't decide where was the best place to do this. Let me know if you have suggestions.