### PR TITLE
assign EV to Q_latent, Close #36

### DIFF
--- a/src/snowclim_model.py
+++ b/src/snowclim_model.py
@@ -227,7 +227,7 @@ def _calculate_energy_fluxes(exist_snow, parameters, input_forcings, lastsnowtem
     )
     energy_var['Q_sensible'][has_snow_and_wind] = H
     energy_var['E'][has_snow_and_wind] = E
-    energy_var['Q_latent'][has_snow_and_wind] = E
+    energy_var['Q_latent'][has_snow_and_wind] = EV
 
     # --- Rain heat flux into snowpack (kJ/m2/timestep) ---
     energy_var['Q_precip'][exist_snow] = const.CW * const.WATERDENS * np.maximum(0, input_forcings['tdmean'][exist_snow]) * newrain[exist_snow]


### PR DESCRIPTION
In the latest code, E instead of EV was assigned to Q_latent, resulting in large difference in the snow simulations between the latest model version and previous ones. This pull request addresses this by assigning EV to Q_latent. With this bug fix, the RMSE of SWE between this simulation and the matlab simulation with bug fixes is 0.77 mm.