### PR TITLE
Fix energy-history leak across sites when batching multiple grid cells

### DIFF
--- a/src/snowclim_model.py
+++ b/src/snowclim_model.py
@@ -299,6 +299,18 @@ def _process_snowpack(input_forcings, parameters, snow_vars, precip, snowpack, c
             setattr(snow_vars, key, value)
 
     snow_vars.Energy = lastenergy.copy()
+    # Cells that had no snow at the start of this timestep should not
+    # accumulate an energy-balance history: without this, when several
+    # independent grid cells/sites are batched into one domain array,
+    # a snow-free cell's energy still gets computed (energy fluxes are
+    # calculated for the whole domain, not gated per cell) and that
+    # spurious value is later averaged into the cold-content-tax energy
+    # smoothing once the cell does accumulate snow. That makes results
+    # for a given site depend on which other sites are batched with it.
+    # Setting Energy to NaN (matching each field's own no-computation default,
+    # and letting downstream np.nanmean-based smoothing ignore it) reproduces
+    # the behavior of running each site as its own single-cell domain.
+    snow_vars.Energy[~snow_vars.ExistSnow] = np.nan
 
     taxed_last_energy = _apply_cold_content_tax(
         snowpack.lastpackcc, parameters, previous_energy, lastenergy)


### PR DESCRIPTION
Fixes #82.

`_run_snowclim_step()` computed energy-balance fluxes for the entire spatial
domain whenever *any* cell in the domain currently had snow, rather than
gating per cell. For a snow-free cell, this produced a real (non-NaN)
`Energy` value from that cell's own forcing inputs, which was picked up by
the `np.nanmean`-based energy-smoothing window in `_apply_cold_content_tax()`
once that cell later accumulated snow (since `SnowModelVariables` otherwise
initializes `Energy` to `NaN`, which `nanmean` correctly ignores).

Net effect: results for a given site depended on which other sites were
batched with it in the same domain array, breaking the assumption that
grid cells/sites evolve independently.

**Fix:** explicitly reset `Energy` to `NaN` for cells with no snow at the
start of the timestep, matching the value they'd have if that timestep's
energy balance had never been computed for them.

**Verification:** ran a single SNOTEL site alone vs. as part of a 170-site
batch (identical forcing inputs). Before the fix, SWE diverged by up to
~16 mm within 9 days. After the fix, tested against 8 sites over a
~4-month (3000-hour) window spanning snow accumulation: batched and
per-site runs now produce identical SWE (max abs diff 0.0).

**Known limitation:** this does not fully resolve #29 — it only prevents
*cross-site* energy-history leakage in batched/vectorized runs, not the
within-a-single-site intermittent-snowpack case (energy from a previous,
now-melted snowpack leaking into a later snowpack at the same site).

@aranhax  — flagging for review before merging, since this changes model
output for any run using multiple sites/cells in one domain array.
